### PR TITLE
add Natchez backend that provides a Logger[F] given a Trace[F]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,15 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: mkdir -p target .js/target core/.native/target core/.js/target core/.jvm/target .jvm/target .native/target project/target
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        run: mkdir -p core/js/target target .js/target .jvm/target .native/target core/native/target core/jvm/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
-        run: tar cf targets.tar target .js/target core/.native/target core/.js/target core/.jvm/target .jvm/target .native/target project/target
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        run: tar cf targets.tar core/js/target target .js/target .jvm/target .native/target core/native/target core/jvm/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
@@ -106,7 +106,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ ThisBuild / developers := List(
   tlGitHubDev("bpholt", "Brian Holt"),
 )
 ThisBuild / tlSonatypeUseLegacyHost := false
+ThisBuild / tlCiReleaseBranches := Seq("main")
 
 val Scala213 = "2.13.10"
 val Scala212 = "2.12.17"
@@ -29,11 +30,29 @@ ThisBuild / mergifyPrRules += MergifyPrRule(
   )
 )
 
-lazy val root = tlCrossRootProject.aggregate(core)
+lazy val root = tlCrossRootProject.aggregate(`log4cats-natchez-backend`)
 
-lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .crossType(CrossType.Pure)
+lazy val `log4cats-natchez-backend` = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Full)
   .in(file("core"))
   .settings(
     name := "log4cats-natchez",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "log4cats-core" % "2.5.0",
+      "org.tpolecat" %%% "natchez-core" % "0.2.2",
+    ),
+  )
+  .jvmSettings(
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %%% "natchez-opentelemetry" % "0.2.2" % Test,
+      "io.opentelemetry" % "opentelemetry-api" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-context" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-exporter-otlp" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-exporter-logging" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-extension-trace-propagators" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-sdk" % "1.20.1" % Test,
+      "io.opentelemetry" % "opentelemetry-sdk-common" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-sdk-trace" % "1.21.0" % Test,
+      "io.opentelemetry" % "opentelemetry-semconv" % "1.21.0-alpha" % Test,
+    )
   )

--- a/core/jvm/src/test/scala/org/typelevel/log4cats/natchez/NatchezExample.scala
+++ b/core/jvm/src/test/scala/org/typelevel/log4cats/natchez/NatchezExample.scala
@@ -1,0 +1,52 @@
+package org.typelevel.log4cats.natchez
+
+import cats._
+import cats.data.Kleisli
+import cats.effect.{Trace => _, _}
+import cats.syntax.all._
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.exporter.logging.LoggingSpanExporter
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.sdk.resources.{Resource => OTResource}
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.`export`.{BatchSpanProcessor, SimpleSpanProcessor}
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
+import natchez._
+import natchez.opentelemetry._
+import org.typelevel.log4cats._
+
+import scala.util.control.NoStackTrace
+
+object NatchezExample extends IOApp.Simple {
+  private def app[F[_] : Applicative : Trace]: F[Unit] =
+    StructuredLogger[F].info(Map("it's me" -> "hi"))("hello") *>
+      StructuredLogger[F].warn(Map("hi" -> "I'm the problem it's me"), new RuntimeException("boom") with NoStackTrace {})("Hmm, might be a problem")
+
+  override def run: IO[Unit] =
+    OpenTelemetry.entryPoint[IO](globallyRegister = true) { builder =>
+      Resource.fromAutoCloseable(IO {
+        BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder().build).build()
+      })
+        .flatMap { bsp =>
+          Resource.fromAutoCloseable(IO {
+            SdkTracerProvider
+              .builder()
+              .setResource {
+                OTResource
+                  .getDefault
+                  .merge(OTResource.create(Attributes.of(
+                    ResourceAttributes.SERVICE_NAME, "NatchezExample",
+                  )))
+              }
+              .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create))
+              .addSpanProcessor(bsp)
+              .build()
+          })
+        }
+        .evalMap(stp => IO(builder.setTracerProvider(stp)))
+    }
+      .use { entryPoint =>
+        entryPoint.root("NatchezExample")
+          .use(app[Kleisli[IO, Span[IO], *]].run)
+      }
+}

--- a/core/shared/src/main/scala/org/typelevel/log4cats/natchez/package.scala
+++ b/core/shared/src/main/scala/org/typelevel/log4cats/natchez/package.scala
@@ -1,0 +1,82 @@
+package org.typelevel.log4cats
+
+import _root_.natchez._
+import cats._
+import cats.syntax.all._
+import org.typelevel.log4cats.extras.LogLevel
+
+package object natchez {
+  /**
+   * `LogLevel` as an OpenTelemetry `SeverityNumber`
+   *
+   * See https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-severitynumber
+   *
+   * @return LogLevel as an OpenTelemetry SeverityNumber, converted to the TraceValue ADT
+   */
+  private val logLevelToSeverityNumber: LogLevel => TraceValue = {
+    case LogLevel.Trace => 1
+    case LogLevel.Debug => 5
+    case LogLevel.Info => 9
+    case LogLevel.Warn => 13
+    case LogLevel.Error => 17
+  }
+
+  /**
+   * `LogLevel` as an OpenTelemetry `SeverityText`
+   *
+   * See https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-severitytext
+   * and https://opentelemetry.io/docs/reference/specification/logs/data-model/#displaying-severity
+   *
+   * @return LogLevel as an OpenTelemetry SeverityNumber, converted to the TraceValue ADT
+   */
+  private val logLevelToSeverityText: LogLevel => TraceValue = {
+    case LogLevel.Trace => "TRACE"
+    case LogLevel.Debug => "DEBUG"
+    case LogLevel.Info => "INFO"
+    case LogLevel.Warn => "WARN"
+    case LogLevel.Error => "ERROR"
+  }
+
+  private val mapContextToTraceValue: Map[String, String] => List[(String, TraceValue)] =
+    _.toList.nested.map(TraceValue.StringValue).value
+
+  implicit def TraceLogger[F[_] : Trace : Applicative]: StructuredLogger[F] = new StructuredLogger[F] {
+    private def log(logLevel: LogLevel,
+                    ctx: Map[String, String],
+                    maybeThrowable: Option[Throwable],
+                    msg: => String): F[Unit] = {
+      val attributes =
+        "event" -> TraceValue.StringValue(msg) ::
+          "severity_number" -> logLevelToSeverityNumber(logLevel) ::
+          "severity_text" -> logLevelToSeverityText(logLevel) ::
+          mapContextToTraceValue(ctx)
+
+      Trace[F].log(attributes: _*) *> maybeThrowable.fold(().pure[F])(Trace[F].attachError)
+    }
+
+    override def trace(ctx: Map[String, String])(msg: => String): F[Unit] = log(LogLevel.Trace, ctx, None, msg)
+    override def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = log(LogLevel.Trace, ctx, t.some, msg)
+    override def trace(message: => String): F[Unit] = log(LogLevel.Trace, Map.empty, None, message)
+    override def trace(t: Throwable)(message: => String): F[Unit] = log(LogLevel.Trace, Map.empty, t.some, message)
+
+    override def debug(ctx: Map[String, String])(msg: => String): F[Unit] = log(LogLevel.Debug, ctx, None, msg)
+    override def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = log(LogLevel.Debug, ctx, t.some, msg)
+    override def debug(message: => String): F[Unit] = log(LogLevel.Debug, Map.empty, None, message)
+    override def debug(t: Throwable)(message: => String): F[Unit] = log(LogLevel.Debug, Map.empty, t.some, message)
+
+    override def info(ctx: Map[String, String])(msg: => String): F[Unit] = log(LogLevel.Info, ctx, None, msg)
+    override def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = log(LogLevel.Info, ctx, t.some, msg)
+    override def info(message: => String): F[Unit] = log(LogLevel.Info, Map.empty, None, message)
+    override def info(t: Throwable)(message: => String): F[Unit] = log(LogLevel.Info, Map.empty, t.some, message)
+
+    override def warn(ctx: Map[String, String])(msg: => String): F[Unit] = log(LogLevel.Warn, ctx, None, msg)
+    override def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = log(LogLevel.Warn, ctx, t.some, msg)
+    override def warn(message: => String): F[Unit] = log(LogLevel.Warn, Map.empty, None, message)
+    override def warn(t: Throwable)(message: => String): F[Unit] = log(LogLevel.Warn, Map.empty, t.some, message)
+
+    override def error(ctx: Map[String, String])(msg: => String): F[Unit] = log(LogLevel.Error, ctx, None, msg)
+    override def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] = log(LogLevel.Error, ctx, t.some, msg)
+    override def error(message: => String): F[Unit] = log(LogLevel.Error, Map.empty, None, message)
+    override def error(t: Throwable)(message: => String): F[Unit] = log(LogLevel.Error, Map.empty, t.some, message)
+  }
+}


### PR DESCRIPTION
This migrates https://github.com/typelevel/log4cats/pull/720 to this separate repo so this artifact can be versioned separately from log4cats. Original PR description:

I was looking at the [OpenTelemetry logging spec](https://opentelemetry.io/docs/reference/specification/logs/) the other day and saw this excerpt:

> This is in essence the philosophy behind OpenTelemetry’s logs support. We embrace existing logging solutions and make sure OpenTelemetry works nicely with existing logging libraries … 
> 
> For traces and metrics OpenTelemetry defines a new API that application developers must use to emit traces and metrics.
>
> For logs we did not take the same path. We realized that there is a much bigger and more diverse legacy in logging space. There are many existing logging libraries in different languages, each having their own API. Many programming languages have established standards for using particular logging libraries.

and it occurred to me that it might be nice to use the familiar log4cats `Logger[F]` interface for logging, even in apps that have Natchez `Trace[F]` wired throughout. 

I think this may also provide an easier migration path in an application that has existing `Logger[F]` statements throughout—one may be able to replace a `Logger` constraint with a `Trace` constraint, and then benefit from those existing log statements getting attached to spans going forward. (Eventually many of those logs will prove redundant and be removed.)