### PR TITLE
squash Typelevel Steward PRs to keep commit history clean

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,8 @@ pull_request_rules:
   - status-success=Build and Test (ubuntu-latest, 3, temurin@17, rootNative)
   - '#approved-reviews-by>=1'
   actions:
-    merge: {}
+    merge:
+      method: squash
 - name: Label core PRs
   conditions:
   - files~=^core/

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ ThisBuild / githubWorkflowScalaVersions := Seq("2.13", "2.12", "3")
 ThisBuild / tlJdkRelease := Some(8)
 
 ThisBuild / mergifyStewardConfig ~= {
-  _.map(_.copy(mergeMinors = true, author = "typelevel-steward[bot]"))
+  _.map(_.copy(mergeMinors = true, author = "typelevel-steward[bot]", action = MergifyAction.Merge(method = Option("squash"))))
 }
 ThisBuild / mergifySuccessConditions += MergifyCondition.Custom("#approved-reviews-by>=1")
 ThisBuild / mergifyPrRules += MergifyPrRule(


### PR DESCRIPTION
The Steward will revert and reapply PRs when merge conflicts come up, which is a little annoying to see in the merge history. Squashing those PRs will hopefully work better.